### PR TITLE
Try to defend the previous simplification :-)

### DIFF
--- a/src/DistanceCalculator.java
+++ b/src/DistanceCalculator.java
@@ -340,9 +340,14 @@ public class DistanceCalculator
     // returns coordinates of the node with smallest distance value
     private Integer[] findMinDistanceNode(Node[][] _labeledBoard, ArrayList<Integer[]> input)
     {
-        int curMininum = Integer.MAX_VALUE;
-        Integer[] curMinimumCoordinates = new Integer[2];
-        for (int i = 0; i < input.size(); i++)
+        if (input.size() == 0) {
+            // Do we need to handle this case?
+            return null;
+        }
+        
+        Integer[] curMinimumCoordinates = input.get(0);
+        int curMininum = findNode(_labeledBoard, curMinimumCoordinates).getCurrentDistance();
+        for (int i = 1; i < input.size(); i++)
         {
             int temp = findNode(_labeledBoard, input.get(i)).getCurrentDistance();
             if (temp < curMininum)
@@ -358,16 +363,11 @@ public class DistanceCalculator
     // returns the minimum distance value of the nodes in the ArrayList
     private int findMinDistance(Node[][] _labeledBoard, ArrayList<Integer[]> input)
     {
-        int curMininum = Integer.MAX_VALUE;
-        for (int i = 0; i < input.size(); i++)
-        {
-            int temp = findNode(_labeledBoard, input.get(i)).getCurrentDistance();
-            if (temp < curMininum)
-            {
-                curMininum = temp;
-            }            
+        Integer[] minDistanceNode = findMinDistanceNode(_labeledBoard, input);
+        if (minDistanceNode == null) { // or you can check if input is empty
+            return Integer.MAX_VALUE;
         }
-        return curMininum;
+        return findNode(_labeledBoard, minDistanceNode).getCurrentDistance();
     }
     
     // takes int[] coordinates and finds the corresponding node in labeledBoard


### PR DESCRIPTION
This is about @EachOneChew 's recent revert commit https://github.com/EachOneChew/Dijkstra-s-Algorithm-FEH/commit/21370877c425439775a454dea3d4893cda793c51

I agree the simplification does not work when ALL elements of `input` have `Integer.MAX` as the current distance. In that case the method `findMinDistanceNode ` would do nothing in its for loop and thus return an uninitialized `Integer[]` which would be consumed by `findMinDistance` to error out.

I hence propose a more robust solution for `findMinDistanceNode` so it will always return a valid coordinate from the input array, assuming the input array is NOT empty.